### PR TITLE
Remove useless clutter.Actor.add_child parameter

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -146,7 +146,7 @@ const EmojiCategory = new Lang.Class({
 				this.menu.close();
 				globalButton.menu.close();
 			}));
-			container.add_child(button, {hover: true});
+			container.add_child(button);
 		}
 	},
 
@@ -512,7 +512,7 @@ const EmojisMenu = new Lang.Class({
 		}
 		
 		for(var i = 0;i<NB_RECENTS;i++){
-			container.add_child(recents[i], {hover: true});
+			container.add_child(recents[i]);
 		}
 		
 		return RecentlyUsed;


### PR DESCRIPTION
My `journalctl` showed tons of

```
Nov 04 14:54:59 t gnome-shell[13471]: JS WARNING: [/home/ronj/.local/share/gnome-shell/extensions/emoji-selector@maestroschan.fr/extension.js 515]: Too many arguments to method Clutter.Actor.add_child: expected 1, got 2
```

https://developer.gnome.org/clutter/stable/ClutterActor.html#clutter-actor-add-child