### PR TITLE
fix top bar icon padding

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -644,12 +644,7 @@ const EmojisMenu = new Lang.Class({
 		let box = new St.BoxLayout();
 		let icon = new St.Icon({ icon_name: 'face-cool-symbolic', style_class: 'system-status-icon emotes-icon'});
 
-		let toplabel = new St.Label({
-			y_align: Clutter.ActorAlign.CENTER
-		});
-
 		box.add(icon);
-		box.add(toplabel);
 		box.add(PopupMenu.arrowIcon(St.Side.BOTTOM));
 		this.actor.add_child(box);
 		this._permanentItems = 0;


### PR DESCRIPTION
an empty label was being added which added extra padding on the right. It was especially noticeable when using a theme that hides the dropdown arrows